### PR TITLE
Nicotine+: add miniupnpc to required dependencies

### DIFF
--- a/nicotine+/PKGBUILD
+++ b/nicotine+/PKGBUILD
@@ -6,9 +6,8 @@ pkgdesc="Soulseek music-sharing client, written in Python"
 arch=('any')
 url="https://github.com/Nicotine-Plus/nicotine-plus"
 license=('GPL')
-depends=('python-pytaglib' 'python-gobject' 'gtk3' 'libnotify')
-optdepends=('python-miniupnpc: UPnP support'
-            'python-feedparser: for Reddit plugin'
+depends=('python-miniupnpc' 'python-pytaglib' 'python-gobject' 'gtk3' 'libnotify')
+optdepends=('python-feedparser: for Reddit plugin'
             'gspell: for spell checking in chat'
             'nuspell: for spell checking in chat'
             'libappindicator-gtk3: for tray icon')


### PR DESCRIPTION
We'd prefer to have UPnP functionality out of the box on every Nicotine+ installation, mainly to make life easier for new users. In Nicotine+ 2.0.0, we moved python-miniupnpc from optional to required dependencies.